### PR TITLE
utils.PriorityQueue.java: priority queue with ordered list

### DIFF
--- a/src/domain/impl/ShortestJobFirst.java
+++ b/src/domain/impl/ShortestJobFirst.java
@@ -1,7 +1,8 @@
 package domain.impl;
 
 import java.util.NoSuchElementException;
-import java.util.PriorityQueue;
+
+import utils.PriorityQueue;
 
 /**
  * This scheduling algorithm uses PriorityQueue for its ready queue, ordered by
@@ -15,10 +16,8 @@ public class ShortestJobFirst extends SchedulingStrategy {
      * Intantiates a new `ShortestJobFirst` with `PriorityQueue` as ready queue.
      */
     public ShortestJobFirst() {
-        ready = new PriorityQueue<>(10,
-                (x, y) -> Integer.valueOf(x.getTimeEstimate()).compareTo(y.getTimeEstimate()));
-        blocked = new PriorityQueue<>(10,
-                (x, y) -> Integer.valueOf(x.getBlockedFor()).compareTo(y.getBlockedFor()));
+        ready = new PriorityQueue<Process, Integer>(x -> x.getTimeEstimate());
+        blocked = new PriorityQueue<Process, Integer>(x -> x.getTimeEstimate());
     }
 
     /**

--- a/src/utils/PriorityQueue.java
+++ b/src/utils/PriorityQueue.java
@@ -1,0 +1,63 @@
+package utils;
+
+import java.util.AbstractQueue;
+import java.util.Iterator;
+import java.util.List;
+import java.util.function.Function;
+import java.util.ArrayList;
+
+public class PriorityQueue<T, S extends Comparable<S>> extends AbstractQueue<T> {
+
+    private List<T> queue = new ArrayList<>();
+    private Function<T, S> getter;
+
+    public PriorityQueue(Function<T, S> getter) {
+        super();
+    
+        this.getter = getter;
+    }
+
+    @Override
+    public boolean offer(T e) {
+        if (e == null) {
+            throw new NullPointerException("Null element");
+        }
+
+        int index = Utils.upperBound(queue, e, getter);
+
+        queue.add(Math.max(0, index), e);
+
+        return true;
+    }
+    
+
+    @Override
+    public T poll() {
+        if (queue.isEmpty()) {
+            return null;
+        }
+
+        return queue.remove(0);
+    }
+    
+
+    @Override
+    public T peek() {
+        if (queue.isEmpty()) {
+            return null;
+        }
+
+        return queue.get(0);
+    }
+
+    @Override
+    public Iterator<T> iterator() {
+        return queue.iterator();
+    }
+
+    @Override
+    public int size() {
+        return queue.size();
+    }
+    
+}

--- a/src/utils/Utils.java
+++ b/src/utils/Utils.java
@@ -26,19 +26,20 @@ public class Utils {
      * @param getter - function to get the property with which to compare
      * elements.
      */
-    public static <T, S extends Comparable<S>> int upperBound(List<T> list, S target, Function<T, S> getter) {
+    public static <T, S extends Comparable<S>> int upperBound(List<T> list, T target, Function<T, S> getter) {
         int l = 0;
-        int r = list.size() - 1;
+        int r = list.size();
         
-        while (l < r) {
+        while (l < r && l < list.size()) {
             int m = (l + r) / 2;
             var element = list.get(m);
             var value = getter.apply(element);
+            var targetValue = getter.apply(target);
 
-            if (value.compareTo(target) <= 0) {
+            if (value.compareTo(targetValue) < 0) {
                 l = m + 1;
             } else {
-                r = m - 1;
+                r = m;
             }
         }
 


### PR DESCRIPTION
This solves an issue with java's native PriorityQueue, in which the
order can't be guaranteed, so sometimes, when we needed to print a
queue, it would apparently be in the wrong order.
This implementation uses an ArrayList as container, and uses upperBound
algorithm to find in O(log n) time the index of insertion of new
elements.
Unfortunately, the whole insertion and removal operations are still
O(n), because the elements must be shifted left/right. A better approach
would be using trees, but currently there's no time to implement one.